### PR TITLE
Ordered set

### DIFF
--- a/ctypeslib/codegen/clangparser.py
+++ b/ctypeslib/codegen/clangparser.py
@@ -11,6 +11,7 @@ from ctypeslib.codegen import cursorhandler
 from ctypeslib.codegen import typedesc
 from ctypeslib.codegen import typehandler
 from ctypeslib.codegen import util
+from ctypeslib.oset import OSet
 from ctypeslib.codegen.handler import DuplicateDefinitionException
 from ctypeslib.codegen.handler import InvalidDefinitionError
 from ctypeslib.codegen.handler import InvalidTranslationUnitException
@@ -70,7 +71,7 @@ class Clang_Parser:
     def __init__(self, flags):
         self.all = collections.OrderedDict()
         # a shortcut to identify registered decl in cases of records
-        self.all_set = set()
+        self.all_set = OSet()
         self.cpp_data = {}
         self._unhandled = []
         self.fields = {}
@@ -83,7 +84,7 @@ class Clang_Parser:
         self.cursorkind_handler = cursorhandler.CursorHandler(self)
         self.typekind_handler = typehandler.TypeHandler(self)
         self.__filter_location = None
-        self.__processed_location = set()
+        self.__processed_location = OSet()
 
     def init_parsing_options(self):
         """Set the Translation Unit to skip functions bodies per default."""

--- a/ctypeslib/codegen/codegenerator.py
+++ b/ctypeslib/codegen/codegenerator.py
@@ -22,6 +22,7 @@ from ctypeslib.codegen import clangparser
 from ctypeslib.codegen import config
 from ctypeslib.codegen import typedesc
 from ctypeslib.codegen import util
+from ctypeslib.oset import OSet
 from ctypeslib.library import Library
 
 log = logging.getLogger("codegen")
@@ -50,8 +51,8 @@ class Generator:
         self.macros = 0
         self.cross_arch_code_generation = cfg.cross_arch
         # what record dependency were generated
-        self.head_generated = set()
-        self.body_generated = set()
+        self.head_generated = OSet()
+        self.body_generated = OSet()
 
     # pylint: disable=method-hidden
     def enable_fundamental_type_wrappers(self):
@@ -570,7 +571,7 @@ class Generator:
             return
         self.enable_structure_type()
         self._structures += 1
-        depends = set()
+        depends = OSet()
         # We only print a empty struct.
         if struct.members is None:
             log.info("No members for: %s", struct.name)

--- a/ctypeslib/oset.py
+++ b/ctypeslib/oset.py
@@ -1,0 +1,18 @@
+class OSet:
+  def __init__(self):
+    self.dict = {}
+  def add(self, v):
+    self.dict[v] = None
+  def update(self, other):
+    self.dict.update({k: None for k in other})
+  def remove(self, v):
+    del self.dict[v]
+  def discard(self, v):
+    if v in self.dict:
+      del self.dict[v]
+  def __contains__(self, item):
+    return item in self.dict
+  def __iter__(self):
+    return iter(self.dict.keys())
+  def __len__(self):
+    return len(self.dict)


### PR DESCRIPTION
Python set is not deterministic and this leads to CI failures in https://github.com/tinygrad/tinygrad/pull/8486 (different ordering of definitions)

Not sure why this non-determinism only lead to different ordering on llvm headers and wasn't a problem in other ones tinygrad is using